### PR TITLE
Close diff view before exiting sublime

### DIFF
--- a/GitDiffView.py
+++ b/GitDiffView.py
@@ -132,6 +132,15 @@ class SelectionChangedEvent(sublime_plugin.EventListener):
             view.run_command('toggle_git_diff_view')
             Event.fire('git_view.close')
 
+    def on_pre_close_project(self, window):
+        layout = Layout(window)
+        views_manager = ViewsManager(window)
+
+        # STATE: GitView is open, will be closed
+        if ViewsManager.is_git_view_open():
+            layout.one_column()
+            views_manager.restore()
+
     def on_selection_modified_async(self, view):
         if not self._is_git_status_view_in_focus(view):
             return


### PR DESCRIPTION
Every so often it happens that I close window without closing diff view. Opening project again forces me to manually restore layout as plugin won't remember previous layout after Sublime was closed.

This PR closes diff_view in `on_pre_close_project` event to make sure next time Sublime starts it will be using desired layout.

The code seems to be working for me and it's based on toggle command, however it's not doing this calls as they were causing errors

```python
git_view = GitView(window, layout)
git_view.close()
```
